### PR TITLE
Add validations of unbonding tx hash

### DIFF
--- a/internal/services/unbonding.go
+++ b/internal/services/unbonding.go
@@ -14,7 +14,12 @@ import (
 // UnbondDelegation verifies the unbonding request and saves the unbonding tx into the DB.
 // It returns an error if the delegation is not eligible for unbonding or if the unbonding request is invalid.
 // If successful, it will change the delegation state to `unbonding_requested`
-func (s *Services) UnbondDelegation(ctx context.Context, stakingTxHashHex, unbondingTxHashHex, txHex, signatureHex string) *types.Error {
+func (s *Services) UnbondDelegation(
+	ctx context.Context,
+	stakingTxHashHex,
+	unbondingTxHashHex,
+	unbondingTxHex,
+	signatureHex string) *types.Error {
 	// 1. check the delegation is eligible for unbonding
 	delegationDoc, err := s.DbClient.FindDelegationByTxHashHex(ctx, stakingTxHashHex)
 	if err != nil {
@@ -43,7 +48,8 @@ func (s *Services) UnbondDelegation(ctx context.Context, stakingTxHashHex, unbon
 	// 2. verify the unbonding request
 	if err := utils.VerifyUnbondingRequest(
 		delegationDoc.StakingTxHashHex,
-		txHex,
+		unbondingTxHashHex,
+		unbondingTxHex,
 		delegationDoc.StakerPkHex,
 		delegationDoc.FinalityProviderPkHex,
 		signatureHex,
@@ -58,7 +64,7 @@ func (s *Services) UnbondDelegation(ctx context.Context, stakingTxHashHex, unbon
 	}
 
 	// 3. save unbonding tx into DB
-	err = s.DbClient.SaveUnbondingTx(ctx, stakingTxHashHex, unbondingTxHashHex, txHex, signatureHex)
+	err = s.DbClient.SaveUnbondingTx(ctx, stakingTxHashHex, unbondingTxHashHex, unbondingTxHex, signatureHex)
 	if err != nil {
 		if ok := db.IsDuplicateKeyError(err); ok {
 			log.Ctx(ctx).Warn().Err(err).Msg("unbonding request already been submitted into the system")

--- a/tests/datagen.go
+++ b/tests/datagen.go
@@ -141,6 +141,11 @@ func generateRandomTx(r *rand.Rand) (*wire.MsgTx, string, error) {
 	return tx, txHex, nil
 }
 
+func randomBytes(r *rand.Rand, n uint64) ([]byte, string) {
+	randomBytes := bbndatagen.GenRandomByteArray(r, n)
+	return randomBytes, hex.EncodeToString(randomBytes)
+}
+
 // generateRandomTimestamp generates a random timestamp before the specified timestamp.
 // If beforeTimestamp is 0, then the current time is used.
 func generateRandomTimestamp(afterTimestamp, beforeTimestamp int64) int64 {


### PR DESCRIPTION
Fixes Coinspect audit issue - `BP1-004`

Alternative solution, would be to remove hash altogether from request body, but this would be api breaking change requiring at least next minor version.