### PR TITLE
add queue health check and test

### DIFF
--- a/cmd/staking-api-service/main.go
+++ b/cmd/staking-api-service/main.go
@@ -78,7 +78,7 @@ func main() {
 
 	queues.StartReceivingMessages()
 
-	healthcheck.StartHealthCheckCron(ctx, queues, "")
+	healthcheck.StartHealthCheckCron(ctx, queues, cfg.Server.HealthCheckInterval)
 
 	apiServer, err := api.New(ctx, cfg, services)
 	if err != nil {

--- a/cmd/staking-api-service/main.go
+++ b/cmd/staking-api-service/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/babylonchain/staking-api-service/internal/api"
 	"github.com/babylonchain/staking-api-service/internal/config"
 	"github.com/babylonchain/staking-api-service/internal/db/model"
+	"github.com/babylonchain/staking-api-service/internal/observability/healthcheck"
 	"github.com/babylonchain/staking-api-service/internal/observability/metrics"
 	"github.com/babylonchain/staking-api-service/internal/queue"
 	"github.com/babylonchain/staking-api-service/internal/services"
@@ -76,6 +77,8 @@ func main() {
 	}
 
 	queues.StartReceivingMessages()
+
+	healthcheck.StartHealthCheckCron(ctx, queues, "")
 
 	apiServer, err := api.New(ctx, cfg, services)
 	if err != nil {

--- a/config/config-docker.yml
+++ b/config/config-docker.yml
@@ -8,6 +8,7 @@ server:
   log-level: debug
   btc-net: "mainnet"
   max-content-length: 4096
+  health-check-interval: 60
 db:
   address: "mongodb://mongodb:27017"
   db-name: staking-api-service

--- a/config/config-docker.yml
+++ b/config/config-docker.yml
@@ -8,7 +8,7 @@ server:
   log-level: debug
   btc-net: "mainnet"
   max-content-length: 4096
-  health-check-interval: 60
+  health-check-interval: 300 # 5 minutes interval
 db:
   address: "mongodb://mongodb:27017"
   db-name: staking-api-service

--- a/config/config-local.yml
+++ b/config/config-local.yml
@@ -8,7 +8,7 @@ server:
   log-level: debug
   btc-net: "signet"
   max-content-length: 4096
-  health-check-interval: 60
+  health-check-interval: 300 # 5 minutes interval
 db:
   address: "mongodb://localhost:27017/?directConnection=true"
   db-name: staking-api-service

--- a/config/config-local.yml
+++ b/config/config-local.yml
@@ -8,6 +8,7 @@ server:
   log-level: debug
   btc-net: "signet"
   max-content-length: 4096
+  health-check-interval: 60
 db:
   address: "mongodb://localhost:27017/?directConnection=true"
   db-name: staking-api-service

--- a/go.mod
+++ b/go.mod
@@ -7,12 +7,13 @@ toolchain go1.22.4
 require (
 	github.com/babylonchain/babylon v0.9.0-rc.1
 	github.com/babylonchain/networks/parameters v0.2.1
-	github.com/babylonchain/staking-queue-client v0.2.1
+	github.com/babylonchain/staking-queue-client v0.3.0
 	github.com/btcsuite/btcd v0.24.0
 	github.com/btcsuite/btcd/btcec/v2 v2.3.2
 	github.com/btcsuite/btcd/btcutil v1.1.5
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0
 	github.com/rabbitmq/amqp091-go v1.9.0
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/viper v1.18.2
 	github.com/swaggo/swag v1.16.3
 	github.com/unrolled/secure v1.14.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.22.4
 require (
 	github.com/babylonchain/babylon v0.9.0-rc.1
 	github.com/babylonchain/networks/parameters v0.2.1
-	github.com/babylonchain/staking-queue-client v0.3.0
+	github.com/babylonchain/staking-queue-client v0.3.1
 	github.com/btcsuite/btcd v0.24.0
 	github.com/btcsuite/btcd/btcec/v2 v2.3.2
 	github.com/btcsuite/btcd/btcutil v1.1.5

--- a/go.sum
+++ b/go.sum
@@ -274,8 +274,8 @@ github.com/babylonchain/babylon v0.9.0-rc.1 h1:mZYKQVHVKFUA2xaEAzJloB1kyePHvZECJ
 github.com/babylonchain/babylon v0.9.0-rc.1/go.mod h1:YFALTW+Kp/b5jSDoA7Z70RggJjAedlmQTrpdeU8c3hY=
 github.com/babylonchain/networks/parameters v0.2.1 h1:OKHiCnwL/UdVN17cMwCrHz/bAjO/USauLiPyNlnVl6E=
 github.com/babylonchain/networks/parameters v0.2.1/go.mod h1:nejhvrL7Iwh5Vunvkg7pnomQZlHnyNzOY9lQaDp6tOA=
-github.com/babylonchain/staking-queue-client v0.2.1 h1:FKbxUUOoCydAsUoj9XQMIQT1S79ThX9p7vVc5yjWm8c=
-github.com/babylonchain/staking-queue-client v0.2.1/go.mod h1:mEgA6N3SnwFwGEOsUYr/HdjpKa13Wck08MS7VY/Icvo=
+github.com/babylonchain/staking-queue-client v0.3.0 h1:rOfs433EeveESdZw4OJjVb5nuaH1QEj5SVpMO+Auvh0=
+github.com/babylonchain/staking-queue-client v0.3.0/go.mod h1:mEgA6N3SnwFwGEOsUYr/HdjpKa13Wck08MS7VY/Icvo=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -1000,6 +1000,8 @@ github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5X
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/regen-network/protobuf v1.3.3-alpha.regen.1 h1:OHEc+q5iIAXpqiqFKeLpu5NwTIkVXUs48vFMwzqpqY4=
 github.com/regen-network/protobuf v1.3.3-alpha.regen.1/go.mod h1:2DjTFR1HhMQhiWC5sZ4OhQ3+NtdbZ6oBDKQwq5Ou+FI=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/go.sum
+++ b/go.sum
@@ -274,8 +274,8 @@ github.com/babylonchain/babylon v0.9.0-rc.1 h1:mZYKQVHVKFUA2xaEAzJloB1kyePHvZECJ
 github.com/babylonchain/babylon v0.9.0-rc.1/go.mod h1:YFALTW+Kp/b5jSDoA7Z70RggJjAedlmQTrpdeU8c3hY=
 github.com/babylonchain/networks/parameters v0.2.1 h1:OKHiCnwL/UdVN17cMwCrHz/bAjO/USauLiPyNlnVl6E=
 github.com/babylonchain/networks/parameters v0.2.1/go.mod h1:nejhvrL7Iwh5Vunvkg7pnomQZlHnyNzOY9lQaDp6tOA=
-github.com/babylonchain/staking-queue-client v0.3.0 h1:rOfs433EeveESdZw4OJjVb5nuaH1QEj5SVpMO+Auvh0=
-github.com/babylonchain/staking-queue-client v0.3.0/go.mod h1:mEgA6N3SnwFwGEOsUYr/HdjpKa13Wck08MS7VY/Icvo=
+github.com/babylonchain/staking-queue-client v0.3.1 h1:lbGG/J+2dEVtDCku8MDmisVWpZYst0uyxjPAxF2Pr88=
+github.com/babylonchain/staking-queue-client v0.3.1/go.mod h1:mEgA6N3SnwFwGEOsUYr/HdjpKa13Wck08MS7VY/Icvo=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -13,15 +13,16 @@ import (
 )
 
 type ServerConfig struct {
-	Host             string        `mapstructure:"host"`
-	Port             int           `mapstructure:"port"`
-	WriteTimeout     time.Duration `mapstructure:"write-timeout"`
-	ReadTimeout      time.Duration `mapstructure:"read-timeout"`
-	IdleTimeout      time.Duration `mapstructure:"idle-timeout"`
-	AllowedOrigins   []string      `mapstructure:"allowed-origins"`
-	BTCNet           string        `mapstructure:"btc-net"`
-	LogLevel         string        `mapstructure:"log-level"`
-	MaxContentLength int64         `mapstructure:"max-content-length"`
+	Host                string        `mapstructure:"host"`
+	Port                int           `mapstructure:"port"`
+	WriteTimeout        time.Duration `mapstructure:"write-timeout"`
+	ReadTimeout         time.Duration `mapstructure:"read-timeout"`
+	IdleTimeout         time.Duration `mapstructure:"idle-timeout"`
+	AllowedOrigins      []string      `mapstructure:"allowed-origins"`
+	BTCNet              string        `mapstructure:"btc-net"`
+	LogLevel            string        `mapstructure:"log-level"`
+	MaxContentLength    int64         `mapstructure:"max-content-length"`
+	HealthCheckInterval int           `mapstructure:"health-check-interval"`
 
 	BTCNetParam *chaincfg.Params
 }
@@ -50,6 +51,10 @@ func (cfg *ServerConfig) Validate() error {
 
 	if cfg.MaxContentLength <= 0 {
 		return fmt.Errorf("MaxContentLength must be a positive integer")
+	}
+
+	if cfg.HealthCheckInterval <= 0 {
+		return fmt.Errorf("HealthCheckInterval must be a positive integer")
 	}
 
 	btcNet, err := utils.GetBtcNetParamesFromString(cfg.BTCNet)

--- a/internal/observability/healthcheck/healthcheck.go
+++ b/internal/observability/healthcheck/healthcheck.go
@@ -2,6 +2,7 @@ package healthcheck
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/babylonchain/staking-api-service/internal/queue"
 	"github.com/robfig/cron/v3"
@@ -15,15 +16,17 @@ func SetLogger(customLogger zerolog.Logger) {
 	logger = customLogger
 }
 
-func StartHealthCheckCron(ctx context.Context, queues *queue.Queues, cronTime string) error {
+func StartHealthCheckCron(ctx context.Context, queues *queue.Queues, cronTime int) error {
 	c := cron.New()
 	logger.Info().Msg("Initiated Health Check Cron")
 
-	if cronTime == "" {
-		cronTime = "@every 1m"
+	if cronTime == 0 {
+    cronTime = 60
 	}
 
-	_, err := c.AddFunc(cronTime, func() {
+	cronSpec := fmt.Sprintf("@every %ds", cronTime)
+
+	_, err := c.AddFunc(cronSpec, func() {
 		queueHealthCheck(queues)
 	})
 

--- a/internal/observability/healthcheck/healthcheck.go
+++ b/internal/observability/healthcheck/healthcheck.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/babylonchain/staking-api-service/internal/observability/metrics"
 	"github.com/babylonchain/staking-api-service/internal/queue"
 	"github.com/robfig/cron/v3"
 	"github.com/rs/zerolog"
@@ -49,6 +50,8 @@ func StartHealthCheckCron(ctx context.Context, queues *queue.Queues, cronTime in
 func queueHealthCheck(queues *queue.Queues) {
 	if err := queues.IsConnectionHealthy(); err != nil {
 		logger.Error().Err(err).Msg("One or more queue connections are not healthy.")
+		// Record service unavailable in metrics
+		metrics.RecordServiceCrash("queue")
 		terminateService()
 	}
 }

--- a/internal/observability/healthcheck/healthcheck.go
+++ b/internal/observability/healthcheck/healthcheck.go
@@ -3,6 +3,7 @@ package healthcheck
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/babylonchain/staking-api-service/internal/queue"
 	"github.com/robfig/cron/v3"
@@ -48,5 +49,11 @@ func StartHealthCheckCron(ctx context.Context, queues *queue.Queues, cronTime in
 func queueHealthCheck(queues *queue.Queues) {
 	if err := queues.IsConnectionHealthy(); err != nil {
 		logger.Error().Err(err).Msg("One or more queue connections are not healthy.")
+		terminateService()
 	}
+}
+
+func terminateService() {
+	logger.Fatal().Msg("Terminating service due to health check failure.")
+	os.Exit(1)
 }

--- a/internal/observability/healthcheck/healthcheck.go
+++ b/internal/observability/healthcheck/healthcheck.go
@@ -1,0 +1,49 @@
+package healthcheck
+
+import (
+	"context"
+
+	"github.com/babylonchain/staking-api-service/internal/queue"
+	"github.com/robfig/cron/v3"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+var logger zerolog.Logger = log.Logger
+
+func SetLogger(customLogger zerolog.Logger) {
+	logger = customLogger
+}
+
+func StartHealthCheckCron(ctx context.Context, queues *queue.Queues, cronTime string) error {
+	c := cron.New()
+	logger.Info().Msg("Initiated Health Check Cron")
+
+	if cronTime == "" {
+		cronTime = "@every 1m"
+	}
+
+	_, err := c.AddFunc(cronTime, func() {
+		queueHealthCheck(queues)
+	})
+
+	if err != nil {
+		return err
+	}
+
+	c.Start()
+
+	go func() {
+		<-ctx.Done()
+		logger.Info().Msg("Stopping Health Check Cron")
+		c.Stop()
+	}()
+
+	return nil
+}
+
+func queueHealthCheck(queues *queue.Queues) {
+	if err := queues.IsConnectionHealthy(); err != nil {
+		logger.Error().Err(err).Msg("One or more queue connections are not healthy.")
+	}
+}

--- a/internal/observability/healthcheck/healthcheck.go
+++ b/internal/observability/healthcheck/healthcheck.go
@@ -3,7 +3,6 @@ package healthcheck
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/babylonchain/staking-api-service/internal/observability/metrics"
 	"github.com/babylonchain/staking-api-service/internal/queue"
@@ -58,5 +57,4 @@ func queueHealthCheck(queues *queue.Queues) {
 
 func terminateService() {
 	logger.Fatal().Msg("Terminating service due to health check failure.")
-	os.Exit(1)
 }

--- a/internal/observability/metrics/metrics.go
+++ b/internal/observability/metrics/metrics.go
@@ -31,6 +31,7 @@ var (
 	unprocessableEntityCounter       *prometheus.CounterVec
 	queueOperationFailureCounter     *prometheus.CounterVec
 	httpResponseWriteFailureCounter  *prometheus.CounterVec
+	serviceCrashCounter							 *prometheus.CounterVec
 )
 
 // Init initializes the metrics package.
@@ -103,12 +104,21 @@ func registerMetrics() {
 		[]string{"status"},
 	)
 
+	serviceCrashCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "service_crash_total",
+			Help: "",
+		},
+		[]string{"type"},
+	)	
+
 	prometheus.MustRegister(
 		httpRequestDurationHistogram,
 		eventProcessingDurationHistogram,
 		unprocessableEntityCounter,
 		queueOperationFailureCounter,
 		httpResponseWriteFailureCounter,
+		serviceCrashCounter,
 	)
 }
 
@@ -150,4 +160,9 @@ func RecordQueueOperationFailure(operation, queuename string) {
 // RecordHttpResponseWriteFailure increments the http response write failure counter.
 func RecordHttpResponseWriteFailure(statusCode int) {
 	httpResponseWriteFailureCounter.WithLabelValues(fmt.Sprintf("%d", statusCode)).Inc()
+}
+
+// RecordServiceCrash increments the service crash counter.
+func RecordServiceCrash(operation string, queuename string) {
+	serviceCrashCounter.WithLabelValues(queuename).Inc()
 }

--- a/internal/observability/metrics/metrics.go
+++ b/internal/observability/metrics/metrics.go
@@ -163,6 +163,6 @@ func RecordHttpResponseWriteFailure(statusCode int) {
 }
 
 // RecordServiceCrash increments the service crash counter.
-func RecordServiceCrash(operation string, queuename string) {
-	serviceCrashCounter.WithLabelValues(queuename).Inc()
+func RecordServiceCrash(service string) {
+	serviceCrashCounter.WithLabelValues(service).Inc()
 }

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -266,9 +266,6 @@ func (q *Queues) IsConnectionHealthy() error {
 	checkQueue := func(name string, client client.QueueClient) {
 		if err := client.Ping(); err != nil {
 			errorMessages = append(errorMessages, fmt.Sprintf("%s is not healthy: %v", name, err))
-
-			// Record service unavailable in metrics
-			metrics.RecordServiceCrash("ping" ,client.GetQueueName())
 		}
 	}
 

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -263,8 +263,11 @@ func recordErrorLog(err *types.Error) {
 func (q *Queues) IsConnectionHealthy() error {
 	var errorMessages []string
 
+	ctx, cancel := context.WithTimeout(context.Background(), 5 * time.Second)
+	defer cancel()
+
 	checkQueue := func(name string, client client.QueueClient) {
-		if err := client.Ping(); err != nil {
+		if err := client.Ping(ctx); err != nil {
 			errorMessages = append(errorMessages, fmt.Sprintf("%s is not healthy: %v", name, err))
 		}
 	}

--- a/tests/config/config-test.yml
+++ b/tests/config/config-test.yml
@@ -8,6 +8,7 @@ server:
   log-level: error
   btc-net: "signet"
   max-content-length: 4096
+  health-check-interval: 2
 db:
   address: "mongodb://localhost:27017"
   db-name: staking-api-service

--- a/tests/healthcheck_test.go
+++ b/tests/healthcheck_test.go
@@ -147,7 +147,7 @@ func TestStartHealthCheckCron(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	err := healthcheck.StartHealthCheckCron(ctx, testServer.Queues, "@every 2s")
+	err := healthcheck.StartHealthCheckCron(ctx, testServer.Queues, testServer.Config.Server.HealthCheckInterval)
 	assert.NoError(t, err)
 
 	time.Sleep(5 * time.Second)

--- a/tests/healthcheck_test.go
+++ b/tests/healthcheck_test.go
@@ -1,17 +1,12 @@
 package tests
 
 import (
-	"context"
 	"encoding/json"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
-	"time"
 
-	"github.com/babylonchain/staking-api-service/internal/observability/healthcheck"
 	testmock "github.com/babylonchain/staking-api-service/tests/mocks"
-	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -129,43 +124,4 @@ func TestSecurityHeaders(t *testing.T) {
 	assert.Equal(t, "DENY", resp.Header.Get("X-Frame-Options"), "expected X-Frame-Options to be DENY")
 	assert.Equal(t, "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://stackpath.bootstrap.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://stackpath.bootstrap.com; img-src 'self' data: https://cdnjs.cloudflare.com https://stackpath.bootstrap.com; font-src 'self' https://cdnjs.cloudflare.com https://stackpath.bootstrap.com; object-src 'none'; frame-ancestors 'self'; form-action 'self'; block-all-mixed-content; base-uri 'self';", resp.Header.Get("Content-Security-Policy"), "expected Swagger Content-Security-Policy")
 	assert.Equal(t, "strict-origin-when-cross-origin", resp.Header.Get("Referrer-Policy"), "expected Referrer-Policy to be strict-origin-when-cross-origin")
-}
-
-func TestStartHealthCheckCron(t *testing.T) {
-	testServer := setupTestServer(t, nil)
-	defer testServer.Close()
-
-	var logBuffer = &strings.Builder{}
-	testLogger := zerolog.New(logBuffer).With().Timestamp().Logger()
-	testLogger.Output(logBuffer)
-	
-	// Temporary set the log level to debug
-	zerolog.SetGlobalLevel(zerolog.DebugLevel)
-
-	healthcheck.SetLogger(testLogger)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	err := healthcheck.StartHealthCheckCron(ctx, testServer.Queues, testServer.Config.Server.HealthCheckInterval)
-	assert.NoError(t, err)
-
-	time.Sleep(5 * time.Second)
-
-	logOutput := logBuffer.String()
-	
-	// Verify the logs are as expected
-	assert.Contains(t, logOutput, "Initiated Health Check Cron")
-	assert.NotContains(t, logOutput, "One or more queue connections are not healthy.")
-	
-	// Stop receiving message in activeStakingQueueClient
-	testServer.Queues.ActiveStakingQueueClient.Stop()
-	
-	time.Sleep(5 * time.Second)
-	
-	logOutput = logBuffer.String()
-
-	assert.Contains(t, logOutput, "One or more queue connections are not healthy.")
-	
-	cancel()
 }


### PR DESCRIPTION
Resolve issue #48
## Changes
- add cron job to ping queues health (default 1 minute, set in config file)
- record service crash in metrics
- test case to check `StartHealthCheckCron` examine its behaviour on healthy and unhealthy state
- terminate service on unhealthy status

added config variable: `HealthCheckInterval` (`health-check-interval`)