### PR TITLE
add ordinal endpoint and tests

### DIFF
--- a/config/config-docker.yml
+++ b/config/config-docker.yml
@@ -27,3 +27,5 @@ queue:
 metrics:
   host: 0.0.0.0
   port: 2112
+external:
+  ordinal_api_url: "http://ord-poc.devnet.babylonchain.io:8888"

--- a/config/config-local.yml
+++ b/config/config-local.yml
@@ -27,3 +27,5 @@ queue:
 metrics:
   host: 0.0.0.0
   port: 2112
+external:
+  ordinal_api_url: "http://ord-poc.devnet.babylonchain.io:8888"

--- a/internal/api/handlers/ordinals.go
+++ b/internal/api/handlers/ordinals.go
@@ -1,0 +1,66 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/babylonchain/staking-api-service/internal/types"
+)
+
+func parseUTXORequestPayload(request *http.Request) ([]types.UTXORequest, *types.Error) {
+	var utxos []types.UTXORequest
+	if err := json.NewDecoder(request.Body).Decode(&utxos); err != nil {
+		return nil, types.NewErrorWithMsg(http.StatusBadRequest, types.BadRequest, "invalid input format")
+	}
+	
+	if len(utxos) == 0 {
+		return nil, types.NewErrorWithMsg(http.StatusBadRequest, types.BadRequest, "empty UTXO array")
+	}
+
+	for _, utxo := range utxos {
+		if utxo.Txid == "" || utxo.Vout < 0 {
+			return nil, types.NewErrorWithMsg(http.StatusBadRequest, types.BadRequest, "invalid UTXO entry")
+		}
+	}
+	return utxos, nil
+}
+
+// VerifyUTXOs @Summary Verify UTXOs
+// @Description Verifies if given UTXOs contain BRC-20 tokens
+// @Accept json
+// @Produce json
+// @Param UTXO body []types.UTXORequest true "Array of UTXOs"
+// @Success 200 {object} types.SafeUTXOResponse "Verification Results"
+// @Failure 400 {object} types.Error "Error: Bad Request"
+// @Failure 500 {object} types.Error "Error: Internal Server Error"
+// @Router /v1/ordinals/verify-utxos [post]
+func (h *Handler) VerifyUTXOs(request *http.Request) (*Result, *types.Error) {
+	utxos, err := parseUTXORequestPayload(request)
+	if err != nil {
+		errDetails := []types.ErrorDetail{
+			{
+				Message:   err.Err.Error(),
+				Status:    err.StatusCode,
+				ErrorCode: string(err.ErrorCode),
+			},
+		}
+		response := types.SafeUTXOResponse{
+			Error: errDetails,
+		}
+		return &Result{
+			Status: http.StatusBadRequest,
+			Data:   response,
+		}, nil
+	}
+
+	results, errDetails := h.services.VerifyUTXOs(request.Context(), utxos)
+	response := types.SafeUTXOResponse{
+		Data:  results,
+		Error: errDetails,
+	}
+
+	return &Result{
+		Status: http.StatusOK,
+		Data:   response,
+	}, nil
+}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -19,6 +19,7 @@ func (a *Server) SetupRoutes(r *chi.Mux) {
 	r.Get("/v1/stats/staker", registerHandler(handlers.GetTopStakerStats))
 	r.Get("/v1/staker/delegation/check", registerHandler(handlers.CheckStakerDelegationExist))
 	r.Get("/v1/delegation", registerHandler(handlers.GetDelegationByTxHash))
+	r.Post("/v1/ordinals/verify-utxos", registerHandler(handlers.VerifyUTXOs))
 
 	r.Get("/swagger/*", httpSwagger.WrapHandler)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	Db      DbConfig          `mapstructure:"db"`
 	Queue   queue.QueueConfig `mapstructure:"queue"`
 	Metrics MetricsConfig     `mapstructure:"metrics"`
+	External ExternalConfig    `mapstructure:"external"`
 }
 
 func (cfg *Config) Validate() error {

--- a/internal/config/external.go
+++ b/internal/config/external.go
@@ -1,0 +1,27 @@
+package config
+
+import (
+	"errors"
+	"net/url"
+)
+
+type ExternalConfig struct {
+	OrdinalAPIURL string `mapstructure:"ordinal_api_url"`
+}
+
+func (cfg *ExternalConfig) Validate() error {
+	if cfg.OrdinalAPIURL == "" {
+		return errors.New("ordinal_api_url cannot be empty")
+	}
+
+	parsedURL, err := url.ParseRequestURI(cfg.OrdinalAPIURL)
+	if err != nil {
+		return errors.New("invalid ordinal_api_url")
+	}
+
+	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
+		return errors.New("ordinal_api_url must start with http or https")
+	}
+
+	return nil
+}

--- a/internal/services/ordinals.go
+++ b/internal/services/ordinals.go
@@ -1,0 +1,95 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/babylonchain/staking-api-service/internal/types"
+)
+
+func (s *Services) VerifyUTXOs(ctx context.Context, utxos []types.UTXORequest) ([]types.SafeUTXO, []types.ErrorDetail) {
+	var results []types.SafeUTXO
+	var errDetails []types.ErrorDetail
+
+	for _, utxo := range utxos {
+		url := fmt.Sprintf("%s/output/%s:%d", s.cfg.External.OrdinalAPIURL, utxo.Txid, utxo.Vout)
+
+		// Create a new HTTP request
+		req, err := http.NewRequest("GET", url, nil)
+		if err != nil {
+			errDetails = append(errDetails, types.ErrorDetail{
+				TxId:      utxo.Txid,
+				Message:   "Failed to create HTTP request.",
+				Status:    http.StatusInternalServerError,
+				ErrorCode: "REQUEST_CREATION_ERROR",
+			})
+			continue
+		}
+
+		// Set the Accept header to application/json
+		req.Header.Set("Accept", "application/json")
+
+		// Perform the HTTP request
+		client := &http.Client{}
+		resp, err := client.Do(req)
+		if err != nil || resp.StatusCode != http.StatusOK {
+			errDetails = append(errDetails, types.ErrorDetail{
+				TxId:      utxo.Txid,
+				Message:   "UTXO not found.",
+				Status:    http.StatusNotFound,
+				ErrorCode: "UTXO_NOT_FOUND",
+			})
+			continue
+		}
+		defer resp.Body.Close()
+
+		bodyBytes, err := io.ReadAll(resp.Body)
+		if err != nil {
+			errDetails = append(errDetails, types.ErrorDetail{
+				TxId:      utxo.Txid,
+				Message:   "Failed to read Ordinal API response.",
+				Status:    http.StatusInternalServerError,
+				ErrorCode: "READ_ERROR",
+			})
+			continue
+		}
+
+		var output types.OrdinalOutputResponse
+		if err := json.Unmarshal(bodyBytes, &output); err != nil {
+			errDetails = append(errDetails, types.ErrorDetail{
+				TxId:      utxo.Txid,
+				Message:   "Failed to decode Ordinal API response.",
+				Status:    http.StatusInternalServerError,
+				ErrorCode: "DECODE_ERROR",
+			})
+			continue
+		}
+
+		// Decode the runes field if it's not empty
+		var runes []string
+		if len(output.Runes) > 0 {
+			if string(output.Runes) != "{}" {
+				if err := json.Unmarshal(output.Runes, &runes); err != nil {
+					errDetails = append(errDetails, types.ErrorDetail{
+						TxId:      utxo.Txid,
+						Message:   "Failed to decode runes field.",
+						Status:    http.StatusInternalServerError,
+						ErrorCode: "DECODE_RUNES_ERROR",
+					})
+					continue
+				}
+			}
+		}
+
+		safe := len(output.Inscriptions) == 0 && len(runes) == 0
+		results = append(results, types.SafeUTXO{
+			TxId: utxo.Txid,
+			Brc20: !safe,
+		})
+	}
+
+	return results, errDetails
+}

--- a/internal/types/ordinals.go
+++ b/internal/types/ordinals.go
@@ -1,0 +1,35 @@
+package types
+
+import "encoding/json"
+
+type UTXORequest struct {
+    Txid string `json:"txid"`
+    Vout int    `json:"vout"`
+}
+
+type SafeUTXO struct {
+    TxId string `json:"txId"`
+    Brc20 bool  `json:"brc20"`
+}
+
+type SafeUTXOResponse struct {
+    Data  []SafeUTXO       `json:"data"`
+    Error []ErrorDetail `json:"error"`
+}
+
+type ErrorDetail struct {
+    TxId      string `json:"txId,omitempty"`
+    Message   string `json:"message"`
+    Status    int    `json:"status"`
+    ErrorCode string `json:"errorCode"`
+}
+
+type OrdinalOutputResponse struct {
+	Value       int             `json:"value"`
+	ScriptPubKey string          `json:"script_pubkey"`
+	Address      string          `json:"address"`
+	Transaction  string          `json:"transaction"`
+	SatRanges    interface{}     `json:"sat_ranges"`
+	Inscriptions []string        `json:"inscriptions"`
+	Runes        json.RawMessage `json:"runes"`
+}

--- a/tests/config/config-test.yml
+++ b/tests/config/config-test.yml
@@ -27,3 +27,5 @@ queue:
 metrics:
   host: 0.0.0.0
   port: 2112
+external:
+  ordinal_api_url: "http://ord-poc.devnet.babylonchain.io:8888"

--- a/tests/ordinal_test.go
+++ b/tests/ordinal_test.go
@@ -1,0 +1,200 @@
+package tests
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/babylonchain/staking-api-service/internal/types"
+)
+
+const (
+	verifyUTXOsPath = "/v1/ordinals/verify-utxos"
+)
+
+func TestVerifyUTXOs(t *testing.T) {
+	testServer := setupTestServer(t, nil)
+	defer testServer.Close()
+
+	t.Run("Happy Path", func(t *testing.T) {
+		// Define the test UTXOs
+		utxos := []types.UTXORequest{
+			{
+				Txid: "6358dbafc9cfaa15a12f9624b1ad2c928c090fa05bff6219572361050bab4055",
+				Vout: 0,
+			},
+		}
+
+		// Marshal the request body
+		requestBodyBytes, err := json.Marshal(utxos)
+		require.NoError(t, err, "marshalling request body should not fail")
+
+		// Make a POST request to the verify UTXOs endpoint
+		verifyUTXOsUrl := testServer.Server.URL + verifyUTXOsPath
+		resp, err := http.Post(verifyUTXOsUrl, "application/json", bytes.NewReader(requestBodyBytes))
+		require.NoError(t, err, "making POST request to verify UTXOs endpoint should not fail")
+		defer resp.Body.Close()
+
+		// Check that the status code is HTTP 200 OK
+		assert.Equal(t, http.StatusOK, resp.StatusCode, "expected HTTP 200 OK status")
+
+		// Read the response body
+		bodyBytes, err := io.ReadAll(resp.Body)
+		require.NoError(t, err, "reading response body should not fail")
+
+		// Unmarshal the response body
+		var response types.SafeUTXOResponse
+		err = json.Unmarshal(bodyBytes, &response)
+		require.NoError(t, err, "unmarshalling response body should not fail")
+
+		// Check that the response data is as expected
+		assert.NotEmpty(t, response.Data, "expected response data to be non-empty")
+		assert.Equal(t, utxos[0].Txid, response.Data[0].TxId, "expected TxId to match")
+		assert.Equal(t, false, response.Data[0].Brc20, "expected Brc20 to be false")
+		assert.Empty(t, response.Error, "expected no errors in the response")
+	})
+
+	t.Run("Invalid Input Format", func(t *testing.T) {
+		// Define an invalid request body (not an array)
+		invalidRequestBody := map[string]interface{}{
+			"txid": "invalid_txid",
+			"vout": 0,
+		}
+
+		// Marshal the invalid request body
+		requestBodyBytes, err := json.Marshal(invalidRequestBody)
+		require.NoError(t, err, "marshalling request body should not fail")
+
+		// Make a POST request to the verify UTXOs endpoint
+		verifyUTXOsUrl := testServer.Server.URL + verifyUTXOsPath
+		resp, err := http.Post(verifyUTXOsUrl, "application/json", bytes.NewReader(requestBodyBytes))
+		require.NoError(t, err, "making POST request to verify UTXOs endpoint should not fail")
+		defer resp.Body.Close()
+
+		// Check that the status code is HTTP 400 Bad Request
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "expected HTTP 400 Bad Request status")
+
+		// Read the response body
+		bodyBytes, err := io.ReadAll(resp.Body)
+		require.NoError(t, err, "reading response body should not fail")
+
+		// Unmarshal the response body
+		var response types.SafeUTXOResponse
+		err = json.Unmarshal(bodyBytes, &response)
+		require.NoError(t, err, "unmarshalling response body should not fail")
+
+		// Check that the response contains an error
+		assert.NotEmpty(t, response.Error, "expected response error to be non-empty")
+		require.Greater(t, len(response.Error), 0, "expected at least one error in the response")
+		assert.Equal(t, "invalid input format", response.Error[0].Message, "expected error message to be 'invalid input format'")
+		assert.Equal(t, http.StatusBadRequest, response.Error[0].Status, "expected error status to be 400")
+		assert.Equal(t, "BAD_REQUEST", response.Error[0].ErrorCode, "expected error code to be 'BAD_REQUEST'")
+	})
+
+	t.Run("UTXO Not Found", func(t *testing.T) {
+		// Define a UTXO that does not exist
+		utxos := []types.UTXORequest{
+			{
+				Txid: "nonexistent_txid",
+				Vout: 0,
+			},
+		}
+
+		// Marshal the request body
+		requestBodyBytes, err := json.Marshal(utxos)
+		require.NoError(t, err, "marshalling request body should not fail")
+
+		// Make a POST request to the verify UTXOs endpoint
+		verifyUTXOsUrl := testServer.Server.URL + verifyUTXOsPath
+		resp, err := http.Post(verifyUTXOsUrl, "application/json", bytes.NewReader(requestBodyBytes))
+		require.NoError(t, err, "making POST request to verify UTXOs endpoint should not fail")
+		defer resp.Body.Close()
+
+		// Check that the status code is HTTP 200 OK
+		assert.Equal(t, http.StatusOK, resp.StatusCode, "expected HTTP 200 OK status")
+
+		// Read the response body
+		bodyBytes, err := io.ReadAll(resp.Body)
+		require.NoError(t, err, "reading response body should not fail")
+
+		// Unmarshal the response body
+		var response types.SafeUTXOResponse
+		err = json.Unmarshal(bodyBytes, &response)
+		require.NoError(t, err, "unmarshalling response body should not fail")
+
+		// Check that the response contains an error
+		assert.NotEmpty(t, response.Error, "expected response error to be non-empty")
+		require.Greater(t, len(response.Error), 0, "expected at least one error in the response")
+		assert.Equal(t, "nonexistent_txid", response.Error[0].TxId, "expected TxId to match")
+		assert.Equal(t, "UTXO not found.", response.Error[0].Message, "expected error message to be 'UTXO not found.'")
+		assert.Equal(t, http.StatusNotFound, response.Error[0].Status, "expected error status to be 404")
+		assert.Equal(t, "UTXO_NOT_FOUND", response.Error[0].ErrorCode, "expected error code to be 'UTXO_NOT_FOUND'")
+	})
+
+	t.Run("Multiple UTXOs", func(t *testing.T) {
+		// Define multiple test UTXOs, including both valid and invalid ones
+		utxos := []types.UTXORequest{
+			{
+				Txid: "6358dbafc9cfaa15a12f9624b1ad2c928c090fa05bff6219572361050bab4055",
+				Vout: 0,
+			},
+			{
+				Txid: "nonexistent_txid_1",
+				Vout: 0,
+			},
+			{
+				Txid: "nonexistent_txid_2",
+				Vout: 1,
+			},
+		}
+
+		// Marshal the request body
+		requestBodyBytes, err := json.Marshal(utxos)
+		require.NoError(t, err, "marshalling request body should not fail")
+
+		// Make a POST request to the verify UTXOs endpoint
+		verifyUTXOsUrl := testServer.Server.URL + verifyUTXOsPath
+		resp, err := http.Post(verifyUTXOsUrl, "application/json", bytes.NewReader(requestBodyBytes))
+		require.NoError(t, err, "making POST request to verify UTXOs endpoint should not fail")
+		defer resp.Body.Close()
+
+		// Check that the status code is HTTP 200 OK
+		assert.Equal(t, http.StatusOK, resp.StatusCode, "expected HTTP 200 OK status")
+
+		// Read the response body
+		bodyBytes, err := io.ReadAll(resp.Body)
+		require.NoError(t, err, "reading response body should not fail")
+
+		// Unmarshal the response body
+		var response types.SafeUTXOResponse
+		err = json.Unmarshal(bodyBytes, &response)
+		require.NoError(t, err, "unmarshalling response body should not fail")
+
+		// Check that the response data is as expected
+		assert.Equal(t, 1, len(response.Data), "expected response data to contain 1 items")
+		
+		// Check that the error is as expected
+		assert.Equal(t, 2, len(response.Error), "expected error to contain 2 items")
+
+		// Validate the first UTXO (should be valid)
+		assert.Equal(t, utxos[0].Txid, response.Data[0].TxId, "expected TxId to match")
+		assert.Equal(t, false, response.Data[0].Brc20, "expected Brc20 to be false")
+
+		// Validate the second UTXO (should be invalid)
+		assert.Equal(t, utxos[1].Txid, response.Error[0].TxId, "expected TxId to match")
+		assert.Equal(t, "UTXO not found.", response.Error[0].Message, "expected error message to be 'UTXO not found.'")
+		assert.Equal(t, http.StatusNotFound, response.Error[0].Status, "expected error status to be 404")
+		assert.Equal(t, "UTXO_NOT_FOUND", response.Error[0].ErrorCode, "expected error code to be 'UTXO_NOT_FOUND'")
+
+		// Validate the third UTXO (should be invalid)
+		assert.Equal(t, utxos[2].Txid, response.Error[1].TxId, "expected TxId to match")
+		assert.Equal(t, "UTXO not found.", response.Error[1].Message, "expected error message to be 'UTXO not found.'")
+		assert.Equal(t, http.StatusNotFound, response.Error[1].Status, "expected error status to be 404")
+		assert.Equal(t, "UTXO_NOT_FOUND", response.Error[1].ErrorCode, "expected error code to be 'UTXO_NOT_FOUND'")
+	})
+}


### PR DESCRIPTION
Config changes:
added 
`external:ordinal_api_url`

TODO: add config in [service deployment](https://github.com/babylonchain/babylon-service-deployment)

Tests:
happy path:
- One UTXO
- Multiple UTXOs

error paths:
- Invalid Input Format
- Invalid Input Format
- UTXOs not found



